### PR TITLE
tabBarBackgroundImageStyleを追加した

### DIFF
--- a/src/Scene.js
+++ b/src/Scene.js
@@ -23,6 +23,7 @@ export default class extends React.Component {
     tabTitleStyle: Text.propTypes.style,
     tabSelectedTitleStyle: Text.propTypes.style,
     tabTitle: PropTypes.string,
+    tabBarBackgroundImageStyle: Image.propTypes.style,
   };
 
   render() {

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -7,7 +7,7 @@
  *
  */
 import React, { PropTypes } from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, Image } from 'react-native';
 
 export default class extends React.Component {
 

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -80,7 +80,10 @@ class TabBar extends Component {
         />
         {!hideTabBar && state.children.filter(el => el.icon).length > 0 &&
           (state.tabBarBackgroundImage ? (
-            <Image source={state.tabBarBackgroundImage}>
+            <Image
+              source={state.tabBarBackgroundImage}
+              style={state.tabBarBackgroundImageStyle}
+            >
               {contents}
             </Image>
           ) : contents)


### PR DESCRIPTION
新しくタブバーの背景画像にスタイルを適用するためのtabBarBackgroundImageStyleを追加しました。

使用例です。

```
                        <Scene
                            key="tabs"
                            tabs
                            tabBarBackgroundImage={IMAGES.BACKGROUND.TAB_BAR}
                            tabBarBackgroundImageStyle={{
                                     height: 50,
                                     width: undefined
                            }}
                            tabBarStyle={styles.tabBar}
                        >
```